### PR TITLE
[nrf fromlist] boards: nrf54h20dk: Add SUIT storage definition

### DIFF
--- a/dts/common/nordic/nrf54h20.dtsi
+++ b/dts/common/nordic/nrf54h20.dtsi
@@ -85,6 +85,10 @@
 		cpuapp_uicr_ext: memory@e1ff800 {
 			reg = <0xe1ff800 DT_SIZE_K(2)>;
 		};
+
+		suit_storage_partition: memory@e1eb000 {
+			reg = <0xe1eb000 DT_SIZE_K(24)>;
+		};
 	};
 
 	clocks {


### PR DESCRIPTION
Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/72810

Add a definition of SUIT storage, so there will be a common source of the SUIT storage location for both SDFW and scripts generating SUIT storage areas, assigned to local domains.