### PR TITLE
[nrf fromlist] boards: nrf54h20dk: Add SUIT storage definition

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-memory_map.dtsi
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-memory_map.dtsi
@@ -191,4 +191,18 @@
 			reg = <0x136000 DT_SIZE_K(24)>;
 		};
 	};
+
+	cpusec_rw_partitions: cpusec-rw-partitions {
+		compatible = "nordic,owned-partitions", "fixed-partitions";
+		status = "disabled";
+		perm-read;
+		perm-write;
+		perm-secure;
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		suit_storage_partition: partition@1eb000 {
+			reg = <0x1eb000 DT_SIZE_K(24)>;
+		};
+	};
 };


### PR DESCRIPTION
Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/72810

Add a definition of SUIT storage, so there will be a common source of the SUIT storage location for both SDFW and scripts generating SUIT storage areas, assigned to local domains.